### PR TITLE
Return proper error when connection fails

### DIFF
--- a/node.go
+++ b/node.go
@@ -128,9 +128,9 @@ func (n *Node) start() (err error) {
 
 	logDebug("[Node]", "(%v) starting", n)
 
-	var i uint16
-	for i = 0; i < n.minConnections; i++ {
-		if conn, err := n.createNewConnection(nil, false); err == nil {
+	for i := uint16(0); i < n.minConnections; i++ {
+		var conn *connection
+		if conn, err = n.createNewConnection(nil, false); err == nil {
 			if conn == nil {
 				// Should never happen
 				panic(fmt.Sprintf("[Node] (%v) could not create connection in Start", n))


### PR DESCRIPTION
Errors from `n.createNewConnection` are not getting returned properly because err is not in scope when instantiated with `:=`. This change fixes that and bubbles the error up properly. 