### PR TITLE
Adding simple Get call on client, to handle boilerplate

### DIFF
--- a/client.go
+++ b/client.go
@@ -143,14 +143,7 @@ func (c *Client) Fetch(bucketType, bucket, key string) ([]*Object, error) {
 }
 
 // Store is a simple invocation of the StorehValueCommand
-func (c *Client) Store(bucketType, bucket, key string, data []byte) ([]*Object, error) {
-	obj := &Object{
-		ContentType:     "application/json",
-		Charset:         "utf-8",
-		ContentEncoding: "utf-8",
-		Value:           data,
-	}
-
+func (c *Client) Store(bucketType, bucket, key string, obj *Object) ([]*Object, error) {
 	cmd, err := NewStoreValueCommandBuilder().
 		WithBucketType(bucketType).
 		WithBucket(bucket).

--- a/client.go
+++ b/client.go
@@ -173,9 +173,9 @@ func (c *Client) Store(bucketType, bucket, key string, data []byte) ([]*Object, 
 	return res.Response.Values, nil
 }
 
-// Fetch is a simple invocation of the NewFetchValueCommand
+// Delete is a simple invocation of the NewFetchValueCommand
 func (c *Client) Delete(bucketType, bucket, key string) error {
-	cmd, err := NewFetchValueCommandBuilder().
+	cmd, err := NewDeleteValueCommandBuilder().
 		WithBucketType(bucketType).
 		WithBucket(bucket).
 		WithKey(key).

--- a/client.go
+++ b/client.go
@@ -25,12 +25,6 @@ type NewClientOptions struct {
 	RemoteAddresses []string // NB: in the form HOST|IP[:PORT]
 }
 
-type Options struct {
-	BucketType string
-	Bucket     string
-	Key        string
-}
-
 // NewClient generates a new Client object using the provided options
 func NewClient(opts *NewClientOptions) (*Client, error) {
 	if opts == nil {

--- a/client.go
+++ b/client.go
@@ -149,6 +149,7 @@ func (c *Client) Store(bucketType, bucket, key string, obj *Object) ([]*Object, 
 		WithBucket(bucket).
 		WithKey(key).
 		WithContent(obj).
+		WithReturnBody(true).
 		Build()
 
 	if err != nil {
@@ -167,12 +168,17 @@ func (c *Client) Store(bucketType, bucket, key string, obj *Object) ([]*Object, 
 }
 
 // Delete is a simple invocation of the NewFetchValueCommand
-func (c *Client) Delete(bucketType, bucket, key string) error {
-	cmd, err := NewDeleteValueCommandBuilder().
+func (c *Client) Delete(bucketType, bucket, key string, vclock []byte) error {
+	builder := NewDeleteValueCommandBuilder().
 		WithBucketType(bucketType).
 		WithBucket(bucket).
-		WithKey(key).
-		Build()
+		WithKey(key)
+
+	if vclock != nil && len(vclock) > 0 {
+		builder = builder.WithVClock(vclock)
+	}
+
+	cmd, err := builder.Build()
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Tossing this as an idea out there - A simple series of Get / Set / Delete methods to make the really common cases a little less boiler-platey to work with.

Example of how I'd see someone using this:

```golang
objs, err := client.Get(&GetOptions{
  Bucket: "b",
  Key :"y",
  BucketType: "bt"
})

if err != nil {
  // stuff
}
```

The idea being, only one error to check, optional BucketType. I think you could do something similar for Set / Delete, would be happy to implement those if you think this approach makes sense.