### PR TITLE
Add an atomic, bounded connection counter

### DIFF
--- a/connection_manager_i_test.go
+++ b/connection_manager_i_test.go
@@ -41,7 +41,7 @@ func TestConnectionManagerDoesNotExpirePastMinConnections(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		time.Sleep(time.Millisecond * 250)
-		if actual, expected := cm.connectionCount, minConnections; actual != expected {
+		if actual, expected := cm.connectionCounter.count(), minConnections; actual != expected {
 			t.Errorf("got: %v, expected: %v", actual, expected)
 		}
 	}


### PR DESCRIPTION
This avoids a buffer underflow error I've seen in the client which caused the connectionCount to go from 0 to 65535