### PR TITLE
Pass auth options to the connection manager in order to be able to create TLS connections

### DIFF
--- a/node.go
+++ b/node.go
@@ -82,6 +82,7 @@ func NewNode(options *NodeOptions) (*Node, error) {
 			idleTimeout:    options.IdleTimeout,
 			connectTimeout: options.ConnectTimeout,
 			requestTimeout: options.RequestTimeout,
+			authOptions:    options.AuthOptions,
 		}
 
 		var cm *connectionManager


### PR DESCRIPTION
Pass authoptions to the connection manager in order to be able to create TLS connections, this fixes the cause of not creating a tls connection on connection/startTls method because authOptions always is nil
