### PR TITLE
Add functions to convert time.Time values to millisecond timestamps.

### DIFF
--- a/examples/cm-client/main.go
+++ b/examples/cm-client/main.go
@@ -50,7 +50,7 @@ func main() {
 		nodeOpts := &riak.NodeOptions{
 			MinConnections: minConnections,
 			MaxConnections: maxConnections,
-			RemoteAddress: addr,
+			RemoteAddress:  addr,
 		}
 		if node, nerr := riak.NewNode(nodeOpts); nerr != nil {
 			util.ErrExit(nerr)
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	opts := &riak.ClusterOptions{
-		Nodes: nodes,
+		Nodes:             nodes,
 		ExecutionAttempts: 3,
 	}
 

--- a/ts_commands.go
+++ b/ts_commands.go
@@ -54,6 +54,14 @@ func (c *TsCell) GetSint64Value() int64 {
 	return c.cell.GetSint64Value()
 }
 
+// GetTimeValue returns the timestamp value stored within the cell as a time.Time
+func (c *TsCell) GetTimeValue() time.Time {
+	ts := c.cell.GetTimestampValue()
+	s := ts / int64(1000)
+	ms := time.Duration(ts%int64(1000)) * time.Millisecond
+	return time.Unix(s, ms.Nanoseconds())
+}
+
 // GetTimestampValue returns the timestamp value stored within the cell
 func (c *TsCell) GetTimestampValue() int64 {
 	return c.cell.GetTimestampValue()
@@ -87,10 +95,23 @@ func NewSint64TsCell(v int64) TsCell {
 	return TsCell{cell: &tsCell}
 }
 
-// NewTimestampTsCell creates a TsCell from a timestamp in int64 form
-func NewTimestampTsCell(v int64) TsCell {
+// NewTimestampTsCell creates a TsCell from a time.Time struct
+func NewTimestampTsCell(t time.Time) TsCell {
+	v := ToUnixMillis(t)
 	tsCell := riak_ts.TsCell{TimestampValue: &v}
 	return TsCell{cell: &tsCell}
+}
+
+// NewTimestampTsCellFromInt64 creates a TsCell from an int64 value
+// that represents *milliseconds* since UTC epoch
+func NewTimestampTsCellFromInt64(v int64) TsCell {
+	tsCell := riak_ts.TsCell{TimestampValue: &v}
+	return TsCell{cell: &tsCell}
+}
+
+// ToUnixMillis converts a time.Time to Unix milliseconds since UTC epoch
+func ToUnixMillis(t time.Time) int64 {
+	return t.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
 }
 
 // TsColumnDescription describes a Time Series column

--- a/ts_commands_test.go
+++ b/ts_commands_test.go
@@ -3,6 +3,7 @@ package riak
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/basho/riak-go-client/rpb/riak_ts"
 )
@@ -96,7 +97,7 @@ func TestBuildTsPutReqCorrectlyViaBuilder(t *testing.T) {
 	row[1] = NewSint64TsCell(1)
 	row[2] = NewDoubleTsCell(0.1)
 	row[3] = NewBooleanTsCell(true)
-	row[4] = NewTimestampTsCell(1234567890)
+	row[4] = NewTimestampTsCellFromInt64(1234567890)
 
 	rows := make([][]TsCell, 1)
 	rows[0] = row
@@ -246,30 +247,52 @@ func TestBuildTsListKeysReqCorrectlyViaBuilder(t *testing.T) {
 }
 
 func TestNewTsCells(t *testing.T) {
+	s := int64(1234567890)
+	ms := time.Duration(103) * time.Millisecond
+	tval := time.Unix(s, ms.Nanoseconds())
+
 	cells := make([]TsCell, 5)
 	cells[0] = NewStringTsCell("Test Key Value")
 	cells[1] = NewSint64TsCell(1)
 	cells[2] = NewDoubleTsCell(0.1)
 	cells[3] = NewBooleanTsCell(true)
-	cells[4] = NewTimestampTsCell(1234567890)
+	cells[4] = NewTimestampTsCell(tval)
 
-	if expected, actual := "VARCHAR", cells[0].GetDataType(); expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
+	if got, want := cells[0].GetDataType(), "VARCHAR"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[0].GetStringValue(), "Test Key Value"; got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 
-	if expected, actual := "SINT64", cells[1].GetDataType(); expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
+	if got, want := cells[1].GetDataType(), "SINT64"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[1].GetSint64Value(), int64(1); got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 
-	if expected, actual := "DOUBLE", cells[2].GetDataType(); expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
+	if got, want := cells[2].GetDataType(), "DOUBLE"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[2].GetDoubleValue(), 0.1; got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 
-	if expected, actual := "BOOLEAN", cells[3].GetDataType(); expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
+	if got, want := cells[3].GetDataType(), "BOOLEAN"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[3].GetBooleanValue(), true; got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 
-	if expected, actual := "TIMESTAMP", cells[4].GetDataType(); expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
+	if got, want := cells[4].GetDataType(), "TIMESTAMP"; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[4].GetTimeValue(), tval; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := cells[4].GetTimestampValue(), int64(1234567890103); got != want {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
These changes allow users to use `time.Time` objects to save data in Riak TS and convert data back, if wanted.