### PR TITLE
Fixing no rows bug in TsQueryResponse

### DIFF
--- a/ts_commands.go
+++ b/ts_commands.go
@@ -496,7 +496,6 @@ func (cmd *TsQueryCommand) onSuccess(msg proto.Message) error {
 			}
 
 			cmd.done = queryResp.GetDone()
-			response := cmd.Response
 
 			tsCols := queryResp.GetColumns()
 			tsRows := queryResp.GetRows()
@@ -523,7 +522,7 @@ func (cmd *TsQueryCommand) onSuccess(msg proto.Message) error {
 						}
 					}
 				} else {
-					response.Rows = append(response.Rows, rows...)
+					cmd.Response.Rows = append(cmd.Response.Rows, rows...)
 				}
 
 			}


### PR DESCRIPTION
If a TsQueryCommand is create with streaming set to false, no rows are returned in the
TsQueryResponse.Rows. The code defines a local variable and puts
the rows in it, and then the rows are lost. I removed the local variable
and set the rows directly to get it working.