### PR TITLE
Fixing no rows bug in TsQueryResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ Thank you to all of our contributors!
 * [Кирилл Александрович Журавлев](https://github.com/kazhuravlev)
 * [Paul Guelpa](https://github.com/pguelpa)
 * [Xabier Larrakoetxea Gallego](https://github.com/slok)
+* [Paul Maseberg](https://github.com/pmaseberg)

--- a/ts_commands.go
+++ b/ts_commands.go
@@ -494,21 +494,23 @@ func (cmd *TsQueryCommand) onSuccess(msg proto.Message) error {
 			if cmd.Response == nil {
 				cmd.Response = &TsQueryResponse{}
 			}
+			response := cmd.Response
 
 			cmd.done = queryResp.GetDone()
-			response := cmd.Response
 
 			tsCols := queryResp.GetColumns()
 			tsRows := queryResp.GetRows()
 			if tsCols != nil && tsRows != nil {
-				cmd.Response = &TsQueryResponse{
-					Columns: make([]TsColumnDescription, 0),
-					Rows:    make([][]TsCell, 0),
+				if tsCols != nil && response.Columns == nil {
+					response.Columns = make([]TsColumnDescription, 0)
+				}
+				if tsRows != nil && response.Rows == nil {
+					response.Rows = make([][]TsCell, 0)
 				}
 
 				for _, tsCol := range tsCols {
 					col.setColumn(tsCol)
-					cmd.Response.Columns = append(cmd.Response.Columns, col)
+					response.Columns = append(response.Columns, col)
 				}
 
 				rows := convertFromPbTsRows(tsRows)
@@ -525,7 +527,6 @@ func (cmd *TsQueryCommand) onSuccess(msg proto.Message) error {
 				} else {
 					response.Rows = append(response.Rows, rows...)
 				}
-
 			}
 		} else {
 			cmd.done = true

--- a/ts_commands_i_test.go
+++ b/ts_commands_i_test.go
@@ -99,6 +99,9 @@ func TestTsDescribeTable(t *testing.T) {
 		if got, want := len(scmd.Response.Columns), 5; !(got >= want) {
 			t.Errorf("expected %v to be greater than or equal to %v", got, want)
 		}
+		if got, want := len(scmd.Response.Rows), 5; !(got >= want) {
+			t.Errorf("expected %v to be greater than or equal to %v", got, want)
+		}
 	} else {
 		t.FailNow()
 	}
@@ -133,8 +136,10 @@ func TestTsCreateTable(t *testing.T) {
 		if expected, actual := true, scmd.success; expected != actual {
 			t.Errorf("expected %v, got %v", expected, actual)
 		}
-
 		if expected, actual := 0, len(scmd.Response.Columns); expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 0, len(scmd.Response.Rows); expected != actual {
 			t.Errorf("expected %v, got %v", expected, actual)
 		}
 	} else {
@@ -339,8 +344,10 @@ func TestTsQuery(t *testing.T) {
 		if expected, actual := true, scmd.success; expected != actual {
 			t.Errorf("expected %v, got %v", expected, actual)
 		}
-
 		if expected, actual := 7, len(scmd.Response.Columns); expected != actual {
+			t.Errorf("expected %v, got %v", expected, actual)
+		}
+		if expected, actual := 1, len(scmd.Response.Rows); expected != actual {
 			t.Errorf("expected %v, got %v", expected, actual)
 		}
 	} else {


### PR DESCRIPTION
Incorporates code from #77 (CLIENTS-497) (CLIENTS-497)

From #77 (CLIENTS-497) (CLIENTS-497):

If the query is create with streaming set to false, no rows were in the
TsQueryResponse.Rows. The code defines a local variable and puts
the rows in it, and then the rows are lost. I removed the local variable
and set the rows direclty to get it working.