### PR TITLE
Adding tests for Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 go:
   - 1.6.x
   - 1.7.x
+  - master
 env:
   global:
     - RIAK_HOST=localhost
@@ -20,6 +21,9 @@ script:
   - make test
   - sudo riak-admin security enable
   - make security-test
+matrix:
+  allow_failures:
+  - go: master
 notifications:
   slack:
     secure: czHGTocw0ERiYsnE+CsW6FRs0PM1YU7fleorn5QGxi4gAjbvk+PVEr4YgiJutzJWs+AMCRn8MdIHRTLUcCVewmXDKeLUBRf4Nj8pSgEsOqEHK+ftE35Gy5jNBqGCMr90YF5rSaNCkBFnlW+cy45Z2fvVoy/YkKjlQ2u7A0B1fvZVCHCRT7R3rKkaTApMEp/2gKxKL+7tcITTd0Jh1YdMurhEIo/CXspv57fcerCiRI4vdVj9iup/ZcbvdW4wx5557alvvj4uYntLbsj94cY6ox5t/EEehy8HOBn7pDUAwAbfadQ574EhZMHK0EZMnS3KHMHKf7/xP5inMfplNbIqqMMQ4yHH1vj49l2WdmVOJPWPJs5y9XNV5q9LDkJnp+ZgVLSYBLgzSnzCjJny/p5HH5lUAuaEzOPrif6rOD7zO0swWZDim5kQv5MKC5HK/7BJeLbT7hFHFTZ6gmzB4DFBSiSCfIYRdCrxylJnwiRT5yATKZfVQDBbFs9bwgeDNW3wXLtpZy+0Lx/q1fWi2Z0ZyuvQzOYSt0fLUXMoJILWmXSpWVSFpW4f6tl8kmEStPPPs5DnNOLlc8haZiaIfX9vpeYWBMMZBTl0Gs/ddCbzROTvvInJjkR1liJXmpKtzDYSCafy5ZUYPxSyg8s/mQVAhm+7FMZ/KC6f9gxonaw8oM0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: required
 dist: trusty
 language: go
+go:
+  - 1.6.x
+  - 1.7.x
 env:
   global:
     - RIAK_HOST=localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ script:
   - make test
   - sudo riak-admin security enable
   - make security-test
-matrix:
-  allow_failures:
-  - go: master
 notifications:
   slack:
     secure: czHGTocw0ERiYsnE+CsW6FRs0PM1YU7fleorn5QGxi4gAjbvk+PVEr4YgiJutzJWs+AMCRn8MdIHRTLUcCVewmXDKeLUBRf4Nj8pSgEsOqEHK+ftE35Gy5jNBqGCMr90YF5rSaNCkBFnlW+cy45Z2fvVoy/YkKjlQ2u7A0B1fvZVCHCRT7R3rKkaTApMEp/2gKxKL+7tcITTd0Jh1YdMurhEIo/CXspv57fcerCiRI4vdVj9iup/ZcbvdW4wx5557alvvj4uYntLbsj94cY6ox5t/EEehy8HOBn7pDUAwAbfadQ574EhZMHK0EZMnS3KHMHKf7/xP5inMfplNbIqqMMQ4yHH1vj49l2WdmVOJPWPJs5y9XNV5q9LDkJnp+ZgVLSYBLgzSnzCjJny/p5HH5lUAuaEzOPrif6rOD7zO0swWZDim5kQv5MKC5HK/7BJeLbT7hFHFTZ6gmzB4DFBSiSCfIYRdCrxylJnwiRT5yATKZfVQDBbFs9bwgeDNW3wXLtpZy+0Lx/q1fWi2Z0ZyuvQzOYSt0fLUXMoJILWmXSpWVSFpW4f6tl8kmEStPPPs5DnNOLlc8haZiaIfX9vpeYWBMMZBTl0Gs/ddCbzROTvvInJjkR1liJXmpKtzDYSCafy5ZUYPxSyg8s/mQVAhm+7FMZ/KC6f9gxonaw8oM0=


### PR DESCRIPTION
Despite the highest minor version of Go being the only supported version, I think it is important to include tests for the current and most recent minors.