### PR TITLE
Make loggers configurable

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -18,7 +18,6 @@ package riak
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 )
@@ -27,7 +26,7 @@ import (
 var EnableDebugLogging = false
 
 var errLogger = log.New(os.Stderr, "", log.LstdFlags)
-var logger = log.New(os.Stderr, "", log.LstdFlags)
+var stdLogger = log.New(os.Stderr, "", log.LstdFlags)
 
 func init() {
 	if debugEnvVar := os.Getenv("RIAK_GO_CLIENT_DEBUG"); debugEnvVar != "" {
@@ -35,33 +34,39 @@ func init() {
 	}
 }
 
-// setLogWriter replaces the default log writer, which uses Stderr
-func setLogWriter(out io.Writer) {
-	logger = log.New(out, "", log.LstdFlags)
+// SetLogger sets the standard logger used for
+// WARN and DEBUG (if enabled)
+func SetLogger(logger *log.Logger) {
+	stdLogger = logger
+}
+
+// SetErrorLogger sets the logger used for errors
+func SetErrorLogger(logger *log.Logger) {
+	errLogger = logger
 }
 
 // logDebug writes formatted string debug messages using Printf only if debug logging is enabled
 func logDebug(source, format string, v ...interface{}) {
 	if EnableDebugLogging {
-		logger.Printf(fmt.Sprintf("[DEBUG] %s %s", source, format), v...)
+		stdLogger.Printf(fmt.Sprintf("[DEBUG] %s %s", source, format), v...)
 	}
 }
 
 // logDebugln writes string debug messages using Println
 func logDebugln(source string, v ...interface{}) {
 	if EnableDebugLogging {
-		logger.Println("[DEBUG]", source, v)
+		stdLogger.Println("[DEBUG]", source, v)
 	}
 }
 
 // logWarn writes formatted string warning messages using Printf
 func logWarn(source, format string, v ...interface{}) {
-	logger.Printf(fmt.Sprintf("[WARNING] %s %s", source, format), v...)
+	stdLogger.Printf(fmt.Sprintf("[WARNING] %s %s", source, format), v...)
 }
 
 // logWarnln writes string warning messages using Println
 func logWarnln(source string, v ...interface{}) {
-	logger.Println("[WARNING]", source, v)
+	stdLogger.Println("[WARNING]", source, v)
 }
 
 // logError writes formatted string error messages using Printf

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,107 @@
+package riak
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestLog(t *testing.T) {
+	EnableDebugLogging = true
+
+	tests := []struct {
+		setLoggerFunc func(*log.Logger)
+		logFunc       func(string, string, ...interface{})
+		prefix        string
+	}{
+		{
+			SetErrorLogger,
+			logError,
+			"[ERROR]",
+		},
+		{
+			SetLogger,
+			logWarn,
+			"[WARNING]",
+		},
+		{
+			SetLogger,
+			logDebug,
+			"[DEBUG]",
+		},
+	}
+
+	for _, tt := range tests {
+		buf := &bytes.Buffer{}
+		logger := log.New(buf, "", log.LstdFlags)
+		tt.setLoggerFunc(logger)
+		tt.logFunc("[test]", "Hello %s!", "World")
+
+		actual := buf.String()
+		suffix := fmt.Sprintf("%s %s", tt.prefix, "[test] Hello World!\n")
+
+		if !strings.HasSuffix(actual, suffix) {
+			t.Errorf("Expected %s to end with %s", actual, suffix)
+		}
+	}
+}
+
+func TestLogln(t *testing.T) {
+	EnableDebugLogging = true
+
+	tests := []struct {
+		setLoggerFunc func(*log.Logger)
+		logFunc       func(string, ...interface{})
+		prefix        string
+	}{
+		{
+			SetErrorLogger,
+			logErrorln,
+			"[ERROR]",
+		},
+		{
+			SetLogger,
+			logWarnln,
+			"[WARNING]",
+		},
+		{
+			SetLogger,
+			logDebugln,
+			"[DEBUG]",
+		},
+	}
+
+	for _, tt := range tests {
+		buf := &bytes.Buffer{}
+		logger := log.New(buf, "", log.LstdFlags)
+		tt.setLoggerFunc(logger)
+		tt.logFunc("[test]", "Hello", "World!")
+
+		actual := buf.String()
+		suffix := fmt.Sprintf("%s %s", tt.prefix, "[test] [Hello World!]\n")
+
+		if !strings.HasSuffix(actual, suffix) {
+			t.Errorf("Expected %s to end with %s", actual, suffix)
+		}
+	}
+}
+
+func TestDebugDisabled(t *testing.T) {
+	EnableDebugLogging = false
+
+	buf := &bytes.Buffer{}
+	logger := log.New(buf, "", log.LstdFlags)
+	SetLogger(logger)
+
+	logDebug("[test]", "Hello %s!", "World")
+	logDebugln("[test]", "Hello", "World")
+
+	actual := buf.String()
+
+	if len(actual) != 0 {
+		t.Errorf("Debug was disabled but got %s", actual)
+	}
+
+}


### PR DESCRIPTION
This PR looks to fix #67 (CLIENTS-856) while being minimally invasive.

I considered breaking out the WARN and DEBUG loggers allowing per-level configuration.  At the end of the day I don't feel strongly one way or the other and went with what felt like the spirit of the original design.

I also threw in some fairly wet unit tests, let me know if you'd like them tightened up.

Thanks!
