### PR TITLE
Wraps byte array generation in method to return nil if empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,4 @@ Thank you to all of our contributors!
 * [Paul Maseberg](https://github.com/pmaseberg)
 * [Weerasak Chongnguluam](https://github.com/iporsut)
 * [Hawk Newton](https://github.com/hawknewton)
+* [Beau Brewer](https://github.com/beaubrewer)

--- a/object.go
+++ b/object.go
@@ -151,9 +151,9 @@ func fromRpbContent(rpbContent *rpbRiakKV.RpbContent) (ro *Object, err error) {
 func toRpbContent(ro *Object) (*rpbRiakKV.RpbContent, error) {
 	rpbContent := &rpbRiakKV.RpbContent{
 		Value:           ro.Value,
-		ContentType:     []byte(ro.ContentType),
-		Charset:         []byte(ro.Charset),
-		ContentEncoding: []byte(ro.ContentEncoding),
+		ContentType:     byteString(ro.ContentType),
+		Charset:         byteString(ro.Charset),
+		ContentEncoding: byteString(ro.ContentEncoding),
 	}
 
 	if ro.HasIndexes() {
@@ -201,4 +201,11 @@ func toRpbContent(ro *Object) (*rpbRiakKV.RpbContent, error) {
 	}
 
 	return rpbContent, nil
+}
+
+func byteString(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	return []byte(s)
 }


### PR DESCRIPTION
Fix for [issue #92 (CLIENTS-593) (CLIENTS-1107)](https://github.com/basho/riak-go-client/issues/92)
Possible solution to prevent empty byte arrays from getting added to the protobuff object.

This caused empty headers to get created i.e. Content-Encoding when not set in the client.