### PR TITLE
Infinite loop in ExecuteOnNode() when all nodes error.

### DIFF
--- a/node_manager.go
+++ b/node_manager.go
@@ -67,6 +67,10 @@ func (nm *defaultNodeManager) ExecuteOnNode(nodes []*Node, command Command, prev
 			break
 		}
 
+    if err != nil {
+	    return executed, err
+    }
+
 		nm.RLock()
 		if startingIndex == nm.nodeIndex {
 			nm.RUnlock()


### PR DESCRIPTION
When a command is sent to the cluster to be executed an infinite loop will occur when all RIAK nodes error and do not execute the command.  By breaking out of the for loop and returning the error, the cluster re-queues the command until ExecutionAttempts is exceeded and the command finally fails and returns to the client without infinitely looping.

This happened in our case when all RIAK nodes were configured with self signed certs and "InsecureSkipVerify" was not set to true in the TLS config.
